### PR TITLE
Feature/per action bill logs

### DIFF
--- a/handlers/vote_event.py
+++ b/handlers/vote_event.py
@@ -1,20 +1,24 @@
 from pathlib import Path
 import json
 
-from utils.file_utils import format_timestamp, record_error_file
+from utils.file_utils import format_timestamp, record_error_file, write_vote_event_log
 
 
 def handle_vote_event(content, session_folder, output_folder, error_folder, filename):
     """
-    Handles vote event files by routing them into the appropriate bill folder.
-    If the referenced bill does not yet exist, a placeholder is created.
-    Logs and skips files missing a bill_identifier.
+    Handles a vote_event JSON file by:
+
+    1. Creating the associated bill folder (and placeholder if missing)
+    2. Saving the full vote_event as a timestamped log file using result info
+       Format: YYYYMMDDT000000Z_vote_event_<result>.json
+
+    Skips and logs errors if bill_identifier is missing.
 
     Args:
         content (dict): Parsed JSON vote event.
-        session_folder (str): Session folder (e.g., "2023-2024").
-        output_folder (Path): Path to processed data root.
-        error_folder (Path): Path to not-processed data root.
+        session_folder (str): Folder name for the legislative session.
+        output_folder (Path): Base path for processed output.
+        error_folder (Path): Base path for logging unprocessable files.
         filename (str): Original filename (used in logs).
     """
     referenced_bill_id = content.get("bill_identifier")
@@ -43,6 +47,7 @@ def handle_vote_event(content, session_folder, output_folder, error_folder, file
     (save_path / "logs").mkdir(parents=True, exist_ok=True)
     (save_path / "files").mkdir(parents=True, exist_ok=True)
 
+    # Add placeholder if bill doesn't exist
     placeholder_file = save_path / "placeholder.json"
     if not placeholder_file.exists():
         placeholder_content = {"identifier": referenced_bill_id, "placeholder": True}
@@ -50,16 +55,8 @@ def handle_vote_event(content, session_folder, output_folder, error_folder, file
             json.dump(placeholder_content, f, indent=2)
         print(f"📝 Created placeholder for missing bill {referenced_bill_id}")
 
-    start_date = content.get("start_date")
-    timestamp = format_timestamp(start_date) if start_date else None
-
-    if not timestamp:
-        print(f"⚠️ Warning: Vote event missing start_date")
-        timestamp = "unknown"
-
-    file_id = content.get("_id", "unknown_id")
-    filename = f"{timestamp}_vote_event.json"
-    output_file = save_path.joinpath("logs", filename)
-    with open(output_file, "w", encoding="utf-8") as f:
-        json.dump(content, f, indent=2)
-    print(f"✅ Saved vote event {file_id} under bill {referenced_bill_id}")
+    # Save the full vote_event log
+    write_vote_event_log(content, referenced_bill_id, save_path / "logs")
+    print(
+        f"✅ Saved vote event {content.get('_id', 'unknown_id')} under bill {referenced_bill_id}"
+    )

--- a/main.py
+++ b/main.py
@@ -13,8 +13,8 @@ from utils.interactive import clear_output_folder
 # CONFIGURATION
 # -------------------------
 BASE_FOLDER = Path(__file__).resolve().parent
-INPUT_FOLDER = Path(BASE_FOLDER) / "sample_input_files"
-PROJECT_ROOT = Path(BASE_FOLDER) / "SAMPLE_OUTPUT_open_civic_data_blockchain_run"
+INPUT_FOLDER = Path(BASE_FOLDER) / "IL_openstates"
+PROJECT_ROOT = Path(BASE_FOLDER) / "FULL_open_civic_data_blockchain_run"
 ERROR_FOLDER = PROJECT_ROOT / "data_not_processed"
 OUTPUT_FOLDER = PROJECT_ROOT / "data_processed"
 SESSION_LOG_PATH = PROJECT_ROOT / "new_sessions_added.txt"

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 import json
 from pathlib import Path
@@ -20,3 +21,51 @@ def record_error_file(
         content["_original_filename"] = original_filename
     with open(folder / filename, "w", encoding="utf-8") as f:
         json.dump(content, f, indent=2)
+
+
+def slugify(text, max_length=100):
+    """
+    Converts a string to a safe, lowercase, underscore-separated slug.
+    Strips punctuation and truncates long filenames.
+    """
+    text = text.lower()
+    text = re.sub(r"[^\w\s-]", "", text)  # remove punctuation
+    text = re.sub(r"\s+", "_", text)  # convert spaces to underscores
+    text = text.strip("_")
+    return text[:max_length]
+
+
+def write_action_logs(actions, bill_identifier, log_folder):
+    """
+    Writes one JSON file per action for a bill.
+
+    Each file is named: YYYYMMDDT000000Z_<slugified_description>.json
+    File contents: { "action": {action}, "bill_id": <bill_identifier> }
+    """
+    for action in actions:
+        date = action.get("date")
+        desc = action.get("description", "no_description")
+        timestamp = format_timestamp(date) if date else "unknown"
+        slug = slugify(desc)
+
+        filename = f"{timestamp}_{slug}.json"
+        output_file = Path(log_folder) / filename
+
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump({"action": action, "bill_id": bill_identifier}, f, indent=2)
+
+
+def write_vote_event_log(vote_event, bill_identifier, log_folder):
+    """
+    Saves a single vote_event file as a timestamped log with result-based suffix.
+
+    Filename: YYYYMMDDT000000Z_vote_event_<result>.json
+    """
+    date = vote_event.get("start_date")
+    timestamp = format_timestamp(date) if date else "unknown"
+    result = vote_event.get("result", "unknown")
+    filename = f"{timestamp}_vote_event_{slugify(result)}.json"
+
+    output_file = Path(log_folder) / filename
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(vote_event, f, indent=2)


### PR DESCRIPTION
## ✨ Feature: Per-Action and Per-Vote Logging

Each `bill_` and `vote_event_` file now produces timestamped, human-readable logs for transparency and auditability.

---

### ✅ What’s New

#### 🔸 Bill Processing (`bill_*.json`)
- Saves one full bill file named:
  ```
  YYYYMMDDT000000Z_entire_bill.json
  ```
- Loops through `actions[]` and creates one log file per action:
  ```
  YYYYMMDDT000000Z_<slugified_description>.json
  ```
- Truncates long filenames to avoid OS errors

#### 🔸 Vote Event Processing (`vote_event_*.json`)
- Saves each vote as:
  ```
  YYYYMMDDT000000Z_vote_event_<result>.json
  ```
- Uses the `start_date` field for the timestamp
- Uses the raw `result` field for filename suffix (e.g., `pass`, `fail`, or `unknown`)

---

### 🔧 Refactoring & Helpers

- Added `slugify()` and new helpers:
  - `write_action_logs()` for bill actions
  - `write_vote_event_log()` for vote events
- Updated `handle_bill()` and `handle_vote_event()` to use the new structure

---

### 📁 Sample Output

Logs are saved in:
```
data_processed/
  country:us/state:il/...
    bills/
      HB1234/
        logs/
          20240120T000000Z_entire_bill.json
          20240120T000000Z_filed_with_clerk.json
          ...
          20240201T000000Z_vote_event_pass.json
```

---

### 🧪 Tested With

- Real JSON files from `sample_input_files/`
- Deliberately malformed and incomplete files for error validation

---

### 🔄 Next Steps

- Discuss strategy for archiving or flagging placeholder bills once full data is received
- Evaluate file size and performance impacts at scale
- Potential frontend integration for log timeline browsing

